### PR TITLE
Prevents "invalid calling object" error in IE11

### DIFF
--- a/src/debouncer.js
+++ b/src/debouncer.js
@@ -24,7 +24,7 @@ class Debouncer {
    */
   requestTick () {
     if (!this.ticking) {
-      requestAnimationFrame(this.rafCallback || (this.rafCallback = this.update.bind(this)))
+      window.requestAnimationFrame(this.rafCallback || (this.rafCallback = this.update.bind(this)))
       this.ticking = true
     }
   }

--- a/src/debouncer.js
+++ b/src/debouncer.js
@@ -1,4 +1,4 @@
-const requestAnimationFrame = typeof window === 'object' ? window.requestAnimationFrame = window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame : function () {}
+const requestAnimationFrame_ = typeof window === 'object' ? window.requestAnimationFrame = window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame : function () {}
 
 /**
  * Handles debouncing of events via requestAnimationFrame
@@ -24,7 +24,7 @@ class Debouncer {
    */
   requestTick () {
     if (!this.ticking) {
-      window.requestAnimationFrame(this.rafCallback || (this.rafCallback = this.update.bind(this)))
+      requestAnimationFrame_(this.rafCallback || (this.rafCallback = this.update.bind(this)))
       this.ticking = true
     }
   }


### PR DESCRIPTION
Hello,

The raw method "requestAnimationFrame" throws an error in IE11.
This is fixed by explicitly using it under the "window" object.